### PR TITLE
BUG: Fix runtime error related to missing mainWindow()

### DIFF
--- a/PET-IndiC/PETIndiC.py
+++ b/PET-IndiC/PETIndiC.py
@@ -335,7 +335,7 @@ class PETIndiCWidget(ScriptedLoadableModuleWidget):
         if volumeNode and labelNode:
           if labelValue not in volumeNode.labels:
             volumeNode.labels.append(labelValue)
-          pd = qt.QProgressDialog('Calculating...', 'Cancel', 0, 100, mainWindow())
+          pd = qt.QProgressDialog('Calculating...', 'Cancel', 0, 100, slicer.util.mainWindow())
           pd.setModal(True)
           pd.setMinimumDuration(0)
           pd.show()
@@ -356,7 +356,7 @@ class PETIndiCWidget(ScriptedLoadableModuleWidget):
     if labelValue > 0:
       if volumeNode and labelNode:
         if labelValue in volumeNode.labels:
-          pd = qt.QProgressDialog('Calculating...', 'Cancel', 0, 100, mainWindow())
+          pd = qt.QProgressDialog('Calculating...', 'Cancel', 0, 100, slicer.util.mainWindow())
           pd.setModal(True)
           pd.setMinimumDuration(0)
           pd.show()


### PR DESCRIPTION
This commit fixes a regression most likely introduced by r24155 (ENH: Fixes

Error fixed by this commit is the following:

//--------
Traceback (most recent call last):
  File "/home/jcfr/.config/NA-MIC/Extensions-24305/PET-IndiC/lib/Slicer-4.4/qt-scripted-modules/PETIndiC.py", line 338, in labelModified
    pd = qt.QProgressDialog('Calculating...', 'Cancel', 0, 100, mainWindow())
NameError: global name 'mainWindow' is not defined
//--------
